### PR TITLE
Clarify GUID comparisons and probabilities

### DIFF
--- a/src/components/DeepComparisons.tsx
+++ b/src/components/DeepComparisons.tsx
@@ -13,10 +13,8 @@ const Row = ({ title, lead, blurb }: { title: string; lead: string; blurb: strin
 export default function DeepComparisons() {
   const stars = new Decimal('1e22')
   const atomsHuman = new Decimal('7e27')
-  const atomsEarth = new Decimal('1.33e50')
   const idsPerStar = SPACE_122.div(stars)
-  const idsPerAtomYou = SPACE_122.div(atomsHuman)
-  const idsPerAtomEarth = SPACE_122.div(atomsEarth)
+  const idsPerAtomHuman = SPACE_122.div(atomsHuman)
 
   return (
     <section className="py-10 md:py-20">
@@ -31,30 +29,28 @@ export default function DeepComparisons() {
           Stretch your intuition
         </motion.h2>
 
-        <div className="mt-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
           <Row
             title="Stars in the observable universe"
             lead={`${speakableWithName(idsPerStar)} GUIDs per star`}
             blurb="Even if you labeled each of ~10^22 stars with trillions of trillions of unique IDs, you would barely dent the v4 space."
           />
           <Row
-            title="Atoms in you"
-            lead={`${speakableWithName(idsPerAtomYou)} GUIDs per atom`}
-            blurb="A human body has ~7×10^27 atoms. There are still astronomically many v4 GUIDs per atom."
-          />
-          <Row
-            title="Atoms in Earth"
-            lead={`${speakableWithName(idsPerAtomEarth)} GUIDs per atom`}
-            blurb="Even spread across an estimated 10^50 atoms of Earth, each atom could still have massive numbers of unique IDs."
+            title="Atoms in the human body"
+            lead={`${speakableWithName(idsPerAtomHuman)} GUIDs per atom`}
+            blurb="A typical human body has ~7×10^27 atoms, leaving hundreds of millions of v4 GUIDs for every atom."
           />
         </div>
 
         <div className="mt-8 rounded-2xl backdrop-blur-card p-6">
           <p className="text-sm text-white/70">Lottery analogy</p>
           <p className="mt-2 text-white/80">
-            Two specific random v4 GUIDs matching is a 1‑in‑2^122 event (~5.3×10^36). That’s on the order of winning a 1‑in‑292,201,338 lottery about 4–5 times in a row.
+            Two specific random v4 GUIDs matching is a 1‑in‑2^122 event (~5.3×10^36). That’s on the
+            order of winning a 1‑in‑292,201,338 lottery about 4–5 times in a row.
           </p>
-          <p className="mt-2 text-xs text-white/50">Assumes independent drawings; order‑of‑magnitude comparison.</p>
+          <p className="mt-2 text-xs text-white/50">
+            Assumes independent drawings; order‑of‑magnitude comparison.
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/RelatableScenarios.tsx
+++ b/src/components/RelatableScenarios.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import Decimal from 'decimal.js-light'
-import { SPACE_122 } from '../lib/math'
+import { SPACE_122, speakableWithName } from '../lib/math'
 
 const ODDS_POWERBALL = new Decimal('292201338')
 const LN2 = Math.LN2
@@ -25,8 +25,9 @@ export default function RelatableScenarios() {
   const chars62 = charsNeeded(62)
 
   const grains = new Decimal('7.5e18')
-  const twoSameGrainTwiceProb = new Decimal(1).div(grains.pow(2))
-  const pairCollisionProb = new Decimal(1).div(SPACE_122)
+  const grainsSquared = grains.pow(2)
+  const sandOdds = speakableWithName(grainsSquared).replace('about ', '')
+  const guidOdds = speakableWithName(SPACE_122).replace('about ', '')
 
   const cards = [
     {
@@ -34,36 +35,36 @@ export default function RelatableScenarios() {
       lead: `Win Powerball about ${kPowerball.toFixed(2)} times in a row`,
       blurb:
         'Two fresh random v4 GUIDs matching is roughly as unlikely as hitting the Powerball jackpot ~4–5 times in a row.',
-      foot: 'Powerball odds are 1 in 292,201,338 per drawing; assumes independence.'
+      foot: 'Powerball odds are 1 in 292,201,338 per drawing; assumes independence.',
     },
     {
       title: 'Gamer dice',
       lead: `Match a specific ${kD20}-roll D20 sequence`,
       blurb:
         'Write down 28 exact D20 results (like 7, 13, 20, …). Rolling that exact sequence is on the same scale as a two‑GUID collision.',
-      foot: 'Uses base^k ≈ 2^122 with base = 20.'
+      foot: 'Uses base^k ≈ 2^122 with base = 20.',
     },
     {
       title: 'Typing a random code (A–Z, 0–9)',
       lead: `Match a random ${chars36}-character code`,
       blurb:
         'With upper‑case letters and digits only, ~24 random characters is comparable to a two‑GUID collision.',
-      foot: '36^24 is slightly larger than 2^122; 23 would be slightly smaller.'
+      foot: '36^24 is slightly larger than 2^122; 23 would be slightly smaller.',
     },
     {
       title: 'Typing a random code (a–z, A–Z, 0–9)',
       lead: `Match a random ${chars62}-character code`,
       blurb:
         'Using upper+lower+digits, about 21 characters is on the same order as a two‑GUID collision.',
-      foot: '62^21 ≈ 2^122 (order of magnitude).'
+      foot: '62^21 ≈ 2^122 (order of magnitude).',
     },
     {
       title: 'Sand, twice in a row',
       lead: 'Pick the exact same grain twice from all Earth’s beaches',
       blurb:
         'Doing it twice — mixing the sand between picks — is a bit less likely than two random GUIDs matching.',
-      foot: `1/(7.5e18)^2 ≈ ${twoSameGrainTwiceProb.toExponential(2)} vs 1/2^122 ≈ ${pairCollisionProb.toExponential(2)}.`
-    }
+      foot: `Odds: ~1 in ${sandOdds} vs ~1 in ${guidOdds} for two GUIDs colliding.`,
+    },
   ]
 
   return (

--- a/src/components/StatGrid.tsx
+++ b/src/components/StatGrid.tsx
@@ -13,26 +13,26 @@ const items = (() => {
       title: 'Per grain of sand',
       value: `${speakableWithName(perGrain)} GUIDs`,
       foot: '…for every grain of sand on Earth',
-      detail: `~${prettyInt(perGrain)} per grain`
+      detail: `~${prettyInt(perGrain)} per grain`,
     },
     {
       title: 'Per person alive',
       value: `${speakableWithName(perPerson)} GUIDs`,
       foot: '…for each of the ~8 billion people',
-      detail: `${prettyInt(perPerson)} each`
+      detail: `${prettyInt(perPerson)} each`,
     },
     {
       title: 'Time to “run out”',
-      value: `${yearsAt1Bps.toExponential(2)} years`,
+      value: `${speakableWithName(yearsAt1Bps)} years`,
       foot: '…if you minted 1 billion GUIDs per second',
-      detail: `That’s astronomically longer than the age of the universe`
+      detail: `That’s astronomically longer than the age of the universe`,
     },
     {
       title: 'Coin‑flip analogy',
       value: `${coinFlips} flips`,
       foot: 'Equivalent to flipping 122 fair coins',
-      detail: '…and using the exact head/tail sequence as your ID'
-    }
+      detail: '…and using the exact head/tail sequence as your ID',
+    },
   ]
 })()
 


### PR DESCRIPTION
## Summary
- Display GUID depletion time in readable format.
- Replace inaccurate Earth atom comparison with human body atoms.
- Explain sand grain odds using plain-language numbers.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a38b187f78832eb1bdb3cea3329578