### PR TITLE
style: restyle sources section

### DIFF
--- a/src/components/Sources.tsx
+++ b/src/components/Sources.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 export default function Sources() {
   const items = [
@@ -20,18 +21,40 @@ export default function Sources() {
   ]
 
   return (
-    <section className="py-10 md:py-20">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-white/70 text-sm">
-        <h2 className="font-semibold mb-2">Sources</h2>
-        <ol className="list-decimal list-inside space-y-1">
-          {items.map((s) => (
-            <li key={s.id}>
-              <a href={s.url} target="_blank" rel="noopener noreferrer" className="underline">
-                {s.label}
-              </a>
-            </li>
-          ))}
-        </ol>
+    <section id="sources" className="py-10 md:py-20">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl md:text-4xl font-bold text-center"
+        >
+          Sources & references
+        </motion.h2>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="mt-6 backdrop-blur-card rounded-2xl p-6"
+        >
+          <ol className="list-decimal list-inside space-y-2 text-white/80 text-sm">
+            {items.map((s) => (
+              <li key={s.id}>
+                <a
+                  href={s.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {s.label}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </motion.div>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- restyle the sources list with motion and card styling to match site theme

## Testing
- `npx prettier -w src/components/Sources.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49647af7c832e8885dca0fd87e1ea