### PR TITLE
Add social metadata and preview image

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="How unique is a GUID? Explore the math with beautiful, interactive comparisons." />
+    <meta property="og:title" content="How Unique is a GUID?" />
+    <meta property="og:description" content="How unique is a GUID? Explore the math with beautiful, interactive comparisons." />
+    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="How Unique is a GUID?" />
+    <meta name="twitter:description" content="How unique is a GUID? Explore the math with beautiful, interactive comparisons." />
+    <meta name="twitter:image" content="/og-image.svg" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧮</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <rect width="100%" height="100%" fill="#0f172a"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Inter, sans-serif" font-size="64" fill="#ffffff">How Unique is a GUID?</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card meta tags for better sharing
- include custom SVG preview image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49831de58832e98c98a892253bea4