### PR TITLE
Add SVG collision probability chart

### DIFF
--- a/src/components/ProbabilityCalculator.tsx
+++ b/src/components/ProbabilityCalculator.tsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion'
 import Decimal from 'decimal.js-light'
 import { useState, useMemo } from 'react'
 import { collisionProbability, SPACE_122 } from '../lib/math'
+import { collisionSeries, linePath } from '../lib/chart'
 
 export default function ProbabilityCalculator() {
   const examples = [
@@ -27,6 +28,17 @@ export default function ProbabilityCalculator() {
       return { text, interp }
     } catch {
       return { text: 'Invalid', interp: '' }
+    }
+  }, [nStr])
+
+  const chartPath = useMemo(() => {
+    const clean = sanitize(nStr)
+    if (!clean.trim()) return ''
+    try {
+      const pts = collisionSeries(clean)
+      return linePath(pts, 400, 200)
+    } catch {
+      return ''
     }
   }, [nStr])
 
@@ -73,6 +85,16 @@ export default function ProbabilityCalculator() {
                 </button>
               ))}
             </div>
+
+            {chartPath && (
+              <div className="mt-8">
+                <svg viewBox="0 0 400 200" className="w-full h-64 text-accent">
+                  <line x1="0" y1="200" x2="400" y2="200" stroke="currentColor" strokeOpacity="0.2" />
+                  <line x1="0" y1="0" x2="0" y2="200" stroke="currentColor" strokeOpacity="0.2" />
+                  <path d={chartPath} fill="none" stroke="currentColor" strokeWidth="2" />
+                </svg>
+              </div>
+            )}
           </div>
 
           <div className="backdrop-blur-card rounded-2xl p-6">

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,0 +1,31 @@
+import Decimal, { type Numeric } from 'decimal.js-light'
+import { collisionProbability, SPACE_122 } from './math'
+
+export type Point = { x: number; y: number }
+
+// Generate points representing collision probability (%) for n in [0, max]
+export function collisionSeries(max: Numeric, steps = 50): Point[] {
+  const maxDecimal = new Decimal(max)
+  if (maxDecimal.lessThanOrEqualTo(0)) return []
+  const pts: Point[] = []
+  for (let i = 0; i <= steps; i++) {
+    const n = maxDecimal.mul(i).div(steps)
+    const p = collisionProbability(n, SPACE_122).mul(100)
+    pts.push({ x: n.toNumber(), y: p.toNumber() })
+  }
+  return pts
+}
+
+// Convert points into an SVG path within given width/height
+export function linePath(points: Point[], width: number, height: number) {
+  if (points.length === 0) return ''
+  const maxX = Math.max(...points.map((p) => p.x)) || 1
+  const maxY = Math.max(...points.map((p) => p.y)) || 1
+  return points
+    .map((p, i) => {
+      const x = (p.x / maxX) * width
+      const y = height - (p.y / maxY) * height
+      return `${i === 0 ? 'M' : 'L'}${x} ${y}`
+    })
+    .join(' ')
+}


### PR DESCRIPTION
## Summary
- add helper for generating collision probability series and SVG path
- render a simple SVG chart beneath the GUID input form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49bd3a110832ebdb1197748bcbc74