### PR TITLE
Add animated GUID bit grid in hero section

### DIFF
--- a/src/components/BitGrid.tsx
+++ b/src/components/BitGrid.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState, useRef } from 'react'
+import { useInView } from 'framer-motion'
+
+const RESERVED_INDICES = [48, 49, 50, 51, 64, 65]
+const ALL_INDICES = Array.from({ length: 128 }, (_, i) => i)
+const RANDOM_INDICES = ALL_INDICES.filter((i) => !RESERVED_INDICES.includes(i))
+
+export default function BitGrid() {
+  const ref = useRef<HTMLDivElement>(null)
+  const inView = useInView(ref, { amount: 0.5 })
+  const [hovered, setHovered] = useState(false)
+  const [bits, setBits] = useState(() =>
+    ALL_INDICES.map((i) => RESERVED_INDICES.includes(i))
+  )
+
+  const active = inView || hovered
+
+  useEffect(() => {
+    if (!active) return
+    const id = setInterval(() => {
+      setBits((prev) => {
+        const next = [...prev]
+        const idx =
+          RANDOM_INDICES[Math.floor(Math.random() * RANDOM_INDICES.length)]!
+        next[idx] = !next[idx]
+        return next
+      })
+    }, 200)
+    return () => clearInterval(id)
+  }, [active])
+
+  return (
+    <div
+      ref={ref}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="mx-auto mt-6 grid gap-1"
+      style={{ gridTemplateColumns: 'repeat(16, minmax(0,1fr))' }}
+    >
+      {bits.map((bit, i) => (
+        <div
+          key={i}
+          className={`h-3 w-3 sm:h-4 sm:w-4 rounded-sm transition-colors duration-200 ${
+            RESERVED_INDICES.includes(i)
+              ? 'bg-accent'
+              : bit
+              ? 'bg-white'
+              : 'bg-white/10'
+          }`}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { SPACE_128, SPACE_122, BITS_RANDOM_V4, speakable, zerosLine } from '../lib/math'
+import BitGrid from './BitGrid'
 
 export default function Hero() {
   return (
@@ -14,6 +15,7 @@ export default function Hero() {
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight">
             How <span className="text-accent">unique</span> is a GUID?
           </h1>
+          <BitGrid />
           <p className="mt-4 text-white/70 max-w-2xl mx-auto">
             GUIDs (also called UUIDs) are 128‑bit identifiers — think of <span className="font-semibold">128 on/off switches</span>. In version 4 (the random kind), <span className="font-semibold">6 of those switches are reserved</span> to label the version and rules, so <span className="font-semibold">122 switches are truly random</span>. That’s about the same randomness as <span className="font-semibold">122 coin flips</span>.
           </p>


### PR DESCRIPTION
## Summary
- embed dynamic BitGrid beneath hero heading
- animate non-reserved GUID bits on hover or when scrolled into view

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49e0b7318832ea8b837897f753191