### PR TITLE
Add GUID generation code samples with copy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .DS_Store
 .vite
+tsconfig.tsbuildinfo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import WitnessCalculator from './components/WitnessCalculator'
 import Sources from './components/Sources'
 import Summary from './components/Summary'
 import Generator from './components/Generator'
+import CodeSamples from './components/CodeSamples'
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
         <LayersExplainer />
         <WitnessCalculator />
         <Generator />
+        <CodeSamples />
         <Summary />
         <Sources />
       </main>

--- a/src/components/CodeSamples.tsx
+++ b/src/components/CodeSamples.tsx
@@ -32,6 +32,15 @@ const samples = {
       '}',
     ],
   },
+  csharp: {
+    label: 'C#',
+    lines: [
+      'using System;',
+      '',
+      'var id = Guid.NewGuid();',
+      'Console.WriteLine(id);',
+    ],
+  },
 } as const
 
 type SampleKey = keyof typeof samples

--- a/src/components/CodeSamples.tsx
+++ b/src/components/CodeSamples.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Copy, Check } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+const samples = {
+  javascript: {
+    label: 'JavaScript',
+    lines: [
+      "import { randomUUID } from 'crypto'",
+      '',
+      'const id = randomUUID()',
+      'console.log(id)',
+    ],
+  },
+  python: {
+    label: 'Python',
+    lines: ['import uuid', '', 'id = uuid.uuid4()', 'print(id)'],
+  },
+  go: {
+    label: 'Go',
+    lines: [
+      'package main',
+      '',
+      'import (',
+      '  "fmt"',
+      '  "github.com/google/uuid"',
+      ')',
+      '',
+      'func main() {',
+      '  id := uuid.New()',
+      '  fmt.Println(id)',
+      '}',
+    ],
+  },
+} as const
+
+type SampleKey = keyof typeof samples
+
+export default function CodeSamples() {
+  const [active, setActive] = useState<SampleKey>('javascript')
+  const [copied, setCopied] = useState(false)
+
+  const code = samples[active].lines.join('\n')
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <section id="code-samples" className="py-10 md:py-20">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl md:text-4xl font-bold text-center"
+        >
+          Generate GUIDs in your code
+        </motion.h2>
+
+        <div className="mt-8">
+          <div className="flex gap-2">
+            {Object.entries(samples).map(([key, { label }]) => (
+              <button
+                key={key}
+                onClick={() => setActive(key as keyof typeof samples)}
+                className={`rounded-lg px-4 py-2 text-sm font-semibold hover:bg-white/15 ${
+                  active === key ? 'bg-white/10' : 'bg-white/5'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          <div className="relative mt-4">
+            <pre className="rounded-lg bg-white/5 p-4 overflow-x-auto font-mono text-sm">
+              <code>{code}</code>
+            </pre>
+            <button
+              onClick={copy}
+              className="absolute top-2 right-2 inline-flex items-center gap-2 rounded-md bg-white/10 px-2 py-1 text-xs hover:bg-white/15"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -7,7 +7,7 @@ function uuidv4() {
   crypto.getRandomValues(bytes)
   bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40
   bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80
-  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0'))
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
   return [
     hex.slice(0, 4).join(''),
     hex.slice(4, 6).join(''),
@@ -23,7 +23,7 @@ export default function Generator() {
 
   const generate = (count = 5) => {
     const next = Array.from({ length: count }, () => uuidv4())
-    setIds(prev => [...next, ...prev].slice(0, 25))
+    setIds((prev) => [...next, ...prev].slice(0, 25))
   }
 
   const copyAll = async () => {
@@ -47,27 +47,46 @@ export default function Generator() {
 
         <div className="mt-8 backdrop-blur-card rounded-2xl p-6">
           <div className="flex flex-wrap items-center gap-3">
-            <button onClick={() => generate(5)} className="inline-flex items-center gap-2 rounded-xl bg-accent/90 px-4 py-3 font-semibold shadow-glow hover:bg-accent">
+            <button
+              onClick={() => generate(5)}
+              className="inline-flex items-center gap-2 rounded-xl bg-accent/90 px-4 py-3 font-semibold shadow-glow hover:bg-accent"
+            >
               <Sparkles className="h-5 w-5" /> Generate 5
             </button>
-            <button onClick={() => generate(50)} className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-3 font-semibold hover:bg-white/15">
+            <button
+              onClick={() => generate(50)}
+              className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-3 font-semibold hover:bg-white/15"
+            >
               <Sparkles className="h-5 w-5" /> Generate 50
             </button>
-            <button onClick={copyAll} disabled={!ids.length}
-              className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-3 font-semibold hover:bg-white/15 disabled:opacity-50">
+            <button
+              onClick={copyAll}
+              disabled={!ids.length}
+              className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-3 font-semibold hover:bg-white/15 disabled:opacity-50"
+            >
               <Copy className="h-5 w-5" /> {copied ? 'Copied!' : 'Copy all'}
             </button>
           </div>
 
           <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {ids.map((id, i) => (
-              <div key={i} className="rounded-lg bg-white/5 px-3 py-2 font-mono text-sm">{id}</div>
+              <div key={i} className="rounded-lg bg-white/5 px-3 py-2 font-mono text-sm">
+                {id}
+              </div>
             ))}
           </div>
         </div>
 
         <p className="mt-6 text-center text-white/60 text-sm">
-          These are random version‑4 GUIDs generated with the browser’s cryptographically secure RNG.
+          These are random version‑4 GUIDs generated with the browser’s cryptographically secure
+          RNG.
+        </p>
+        <p className="mt-2 text-center text-white/60 text-sm">
+          Want to use GUIDs in your own code? See the{' '}
+          <a href="#code-samples" className="text-accent underline">
+            code samples
+          </a>
+          .
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add CodeSamples component with GUID snippets for JavaScript, Python, and Go, each with copy-to-clipboard
- link CodeSamples near Generator and include navigation link
- ignore TypeScript build artifacts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab6deb9c832e88eefefd01627144